### PR TITLE
Mark devices as spun up after suspend

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,12 @@
+hd-idle (1.5) unstable; urgency=low
+
+  * Monitor the skew between monitoring cycles, on discovery of clock skew
+    reset the drive spin_down status to "spun up" and reset the time to current
+    in order to capture potential high loading or (more likely) recovery from
+    suspend or sleep
+
+ -- Andoni del Olmo <andoni.delolmo@gmail.com>  Sat, 13 Aug 2019 21:15:00 +0100
+
 hd-idle (1.4) unstable; urgency=low
 
   * The parameter "-a" now also supports symlinks for disk names. Thus, disks

--- a/hdidle.go
+++ b/hdidle.go
@@ -198,6 +198,6 @@ func logRemonitor(ds diskstats.DiskStats, file string) {
 }
 
 func (c *Config) String() string {
-	return fmt.Sprintf("defaultIdle=%d, defaultCommand=%s, debug=%t devices=%v",
-		c.Defaults.Idle, c.Defaults.CommandType, c.Defaults.Debug, c.Devices)
+	return fmt.Sprintf("defaultIdle=%d, defaultCommand=%s, debug=%t, devices=%v, logFile=%s",
+		c.Defaults.Idle, c.Defaults.CommandType, c.Defaults.Debug, c.Devices, c.Defaults.LogFile)
 }

--- a/main.go
+++ b/main.go
@@ -98,6 +98,7 @@ func main() {
 	println(config.String())
 
 	interval := poolInterval(config.Devices)
+	config.SkewTime = interval * 3
 	gocron.Every(interval).Seconds().Do(ObserveDiskActivity, config)
 	gocron.NextRun()
 	<-gocron.Start()


### PR DESCRIPTION
- Fixes #1 

Monitor the skew between monitoring cycles, on discovery of clock skew reset the drive spin_down status to "spun up" and reset the time to current in order to capture potential high loading or (more likely) recovery from suspend or sleep.