### PR TITLE
set GOCACHE

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -27,6 +27,7 @@ BUILD_DIR := obj-$(DEB_HOST_GNU_TYPE)
 
 # Required: Put the url (without http://) of your git repo.
 export DH_GOPKG := github.com/adelolmo/hd-idle
+export GOCACHE := $(GOPATH)/pkg
 
 # Required: Put the name of your git repo below.
 GIT_REPO_NAME := hd-idle


### PR DESCRIPTION
- Fixex #2 

Go 1.12 requires the env var GOCACHE set to be able to build.

Added:
`export GOCACHE := $(GOPATH)/pkg`
