### PR TITLE
Fixes #9 - prevent service to die when a device is not found

### DIFF
--- a/hdidle.go
+++ b/hdidle.go
@@ -174,10 +174,14 @@ func spindownDisk(deviceName, command string) {
 	device := fmt.Sprintf("/dev/%s", deviceName)
 	switch command {
 	case SCSI:
-		sgio.StopScsiDevice(device)
+		if err := sgio.StopScsiDevice(device); err != nil {
+			fmt.Printf("cannot spindown scsi disk %s\n. %s", device, err.Error())
+		}
 		return
 	case ATA:
-		sgio.StopAtaDevice(device)
+		if err := sgio.StopAtaDevice(device); err != nil {
+			fmt.Printf("cannot spindown ata disk %s\n. %s", device, err.Error())
+		}
 		return
 	}
 }

--- a/sgio/scsi.go
+++ b/sgio/scsi.go
@@ -1,23 +1,23 @@
 package sgio
 
 import (
+	"fmt"
 	"github.com/benmcclelland/sgio"
-	"log"
 )
 
 // https://en.wikipedia.org/wiki/SCSI_command
 const startStopUnit = 0x1b
 
-func StopScsiDevice(device string) {
+func StopScsiDevice(device string) error {
 	f, err := openDevice(device)
 	if err != nil {
-		log.Fatalln(err)
+		return err
 	}
 
 	senseBuf := make([]byte, sgio.SENSE_BUF_LEN)
 	inqCmdBlk := []uint8{startStopUnit, 0, 0, 0, 0, 0}
 	ioHdr := &sgio.SgIoHdr{
-		InterfaceID:    int32('S'),
+		InterfaceID:    'S',
 		DxferDirection: SgDxferNone,
 		Cmdp:           &inqCmdBlk[0],
 		CmdLen:         uint8(len(inqCmdBlk)),
@@ -26,14 +26,14 @@ func StopScsiDevice(device string) {
 	}
 
 	if err := sgio.SgioSyscall(f, ioHdr); err != nil {
-		log.Fatalln(err)
+		return err
 	}
 
 	if err := sgio.CheckSense(ioHdr, &senseBuf); err != nil {
-		log.Fatalln(err)
+		return err
 	}
 
 	if err := f.Close(); err != nil {
-		log.Fatalf("Cannot close file %s. Error: %s", device, err)
+		return fmt.Errorf("cannot close file %s. Error: %s", device, err)
 	}
 }


### PR DESCRIPTION
Fixes #9 

Log if a device is not accessible and cannot be spun down instead of killing the service.