### PR TITLE
Ignore sense for ata command

### DIFF
--- a/sgio/ata.go
+++ b/sgio/ata.go
@@ -23,11 +23,10 @@ import (
 )
 
 const (
-	sgAta16    = 0x85
+	sgAta16    = 0x85 // ATA PASS-THROUGH(16)
 	sgAta16Len = 16
 
 	sgAtaProtoNonData = 3 << 1
-	sgCdb2CheckCond   = 1 << 5
 	ataUsingLba       = 1 << 6
 
 	ataOpStandbyNow1 = 0xe0 // https://wiki.osdev.org/ATA/ATAPI_Power_Management
@@ -57,7 +56,6 @@ func sendAtaCommand(f *os.File, command uint8) error {
 	var cbd [sgAta16Len]uint8
 	cbd[0] = sgAta16
 	cbd[1] = sgAtaProtoNonData
-	cbd[2] = sgCdb2CheckCond
 	cbd[13] = ataUsingLba
 	cbd[14] = command
 	return sendSgio(f, cbd)
@@ -66,13 +64,13 @@ func sendAtaCommand(f *os.File, command uint8) error {
 func sendSgio(f *os.File, inqCmdBlk [sgAta16Len]uint8) error {
 	senseBuf := make([]byte, sgio.SENSE_BUF_LEN)
 	ioHdr := &sgio.SgIoHdr{
-		InterfaceID:    'S',
-		DxferDirection: SgDxferNone,
-		Cmdp:           &inqCmdBlk[0],
-		CmdLen:         sgAta16Len,
-		Sbp:            &senseBuf[0],
-		MxSbLen:        sgio.SENSE_BUF_LEN,
-		Timeout:        0,
+		InterfaceID:    'S',                //  0	4
+		DxferDirection: SgDxferNone,        //  4 	4
+		CmdLen:         sgAta16Len,         //  8	1
+		MxSbLen:        sgio.SENSE_BUF_LEN, //  9	1
+		Cmdp:           &inqCmdBlk[0],      // 24   8
+		Sbp:            &senseBuf[0],       // 32	8
+		Timeout:        0,                  // 40	4
 	}
 
 	if err := sgio.SgioSyscall(f, ioHdr); err != nil {


### PR DESCRIPTION
- Fixes #33 

Ignore the sense response data to prevent crashes on arm64. It follows the _fire and forget_ approach that hdparm does to bring devices to standby.