### PR TITLE
Update help strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ Command line options:
 + -i *idle_time*          
                         Idle time in seconds for the currently named disk(s)
                         (-a *name*) or for all disks.
+                        Setting this value to `0` will never spin down the disk(s).
                          
 + -c *command_type*       
                         Api call to stop the device. Possible values are `scsi`

--- a/debian/hd-idle.8
+++ b/debian/hd-idle.8
@@ -45,6 +45,7 @@ also be a symlink (e.g. /dev/disk/by-uuid/...)
 .B \-i idle_time
 Idle time in seconds for the currently named disk(s) (-a <name>) or for
 all disks.
+Setting this value to "0" will never spin down the disk(s).
 .TP
 .B \-c command_type
 Api call to stop the device. Possible values are "scsi" (default value)


### PR DESCRIPTION
Indicate in the README and man page that setting the `idle_time` parameter to `0` will not spin down selected disks.