### PR TITLE
Try both ATA standby commands before fail

### DIFF
--- a/sgio/ata.go
+++ b/sgio/ata.go
@@ -40,10 +40,9 @@ func StopAtaDevice(device string) error {
 	}
 
 	if err = sendAtaCommand(f, ataOpStandbyNow1); err != nil {
-		return err
-	}
-	if err = sendAtaCommand(f, ataOpStandbyNow2); err != nil {
-		return err
+		if err = sendAtaCommand(f, ataOpStandbyNow2); err != nil {
+			return err
+		}
 	}
 
 	if err := f.Close(); err != nil {


### PR DESCRIPTION
I have a device (H82-SU3S2) that worked with "hdparm -y" but not hd-idle ata mode, and I spotted this difference between the implementations:
https://github.com/Distrotech/hdparm/blob/4517550db29a91420fb2b020349523b1b4512df2/hdparm.c#L2307-L2310