### PR TITLE
Read and Write counters are unsigned 64 bit values

### DIFF
--- a/diskstats/snapshot.go
+++ b/diskstats/snapshot.go
@@ -84,8 +84,8 @@ const (
 type ReadWriteStats struct {
 	Name   string
 	Type   DeviceType
-	Reads  int
-	Writes int
+	Reads  uint64
+	Writes uint64
 }
 
 var scsiDiskRegex *regexp.Regexp
@@ -198,8 +198,8 @@ func statsForDisk(rawStats string) (*ReadWriteStats, error) {
 
 		name := cols[deviceNameCol]
 		deviceType := Unknown
-		reads, _ := strconv.Atoi(cols[readsCol])
-		writes, _ := strconv.Atoi(cols[writesCol])
+		reads, _ := strconv.ParseUint(cols[readsCol], 10, 64)
+		writes, _ := strconv.ParseUint(cols[writesCol], 10, 64)
 		
 
 		if scsiDiskRegex.MatchString(name) {

--- a/hdidle.go
+++ b/hdidle.go
@@ -58,8 +58,8 @@ type DiskStats struct {
 	Name        string
 	IdleTime    time.Duration
 	CommandType string
-	Reads       int
-	Writes      int
+	Reads       uint64
+	Writes      uint64
 	SpinDownAt  time.Time
 	SpinUpAt    time.Time
 	LastIoAt    time.Time


### PR DESCRIPTION
Apologies in advance if the wording / interpretation of this is not quite right.
Tried building on a system with mixture of 64bit and 32bit ... and it failed because the test module uses long values for reads/writes.
This highlighted issue with how the structure if defined that receives the /proc/diskstats
So explicitly defined them as uint64 rather than letting the compiler guess based on system.