### PR TITLE
Support SAS disks

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,12 @@ Command line options:
                         Api call to stop the device. Possible values are `scsi`
                         (default value) and `ata`.
 
++ -p *power_condition*       
+                        Power condition to send with `SCSI START STOP UNIT` command. Possible values 
+                        are `0-15` (inclusive). The default value of `0` works fine for disks accessible via the
+                        `SCSI` layer (USB, IEEE1394, ...), but it will NOT work with real `SCSI` / `SAS` disks.
+                        Commnon values for  `SAS`disks are `2` for idle and `3` for standby. 
+
 + -s *symlink_policy*   
                         Set the policy to resolve symlinks for devices. If set 
                         to `0`, symlinks are resolved only on start. If set to `1`,

--- a/README.md
+++ b/README.md
@@ -143,10 +143,11 @@ Command line options:
                         (default value) and `ata`.
 
 + -p *power_condition*       
-                        Power condition to send with `SCSI START STOP UNIT` command. Possible values 
+                        Power condition to send with the issued SCSI START STOP UNIT command. Possible values 
                         are `0-15` (inclusive). The default value of `0` works fine for disks accessible via the
-                        `SCSI` layer (USB, IEEE1394, ...), but it will NOT work with real `SCSI` / `SAS` disks.
-                        Commnon values for  `SAS`disks are `2` for idle and `3` for standby. 
+                        SCSI layer (USB, IEEE1394, ...), but it will *NOT* work as intended with real SCSI / SAS disks.
+                        A stopped SAS disk will not start up automatically on access, but requires a startup command for reactivation.
+                        Useful values for  SAS disks are `2` for idle and `3` for standby. 
 
 + -s *symlink_policy*   
                         Set the policy to resolve symlinks for devices. If set 
@@ -277,14 +278,6 @@ to spin down after a few seconds you may damage the disk over time due to the
 stress the spin-up causes on the spindle motor and bearings. It seems that
 manufacturers recommend a minimum idle time of 3-5 minutes, the default in
 `hd-idle` is 10 minutes.
-
-One more word of caution: `hd-idle` will spin down any disk accessible via the
-`SCSI` layer (USB, IEEE1394, ...) but it will NOT work with real `SCSI` disks
-because they don't spin up automatically. Thus it's not called scsi-idle and
-I don't recommend using it on a real `SCSI` system unless you have a kernel
-patch that automatically starts the `SCSI` disks after receiving a sense buffer
-indicating the disk has been stopped. Without such a patch, real `SCSI` disks
-won't start again and you can as well pull the plug.
 
 You have been warned...
 

--- a/hdidle.go
+++ b/hdidle.go
@@ -209,6 +209,7 @@ func deviceConfig(diskName string, config *Config) *DeviceConf {
 	return &DeviceConf{
 		Name:        diskName,
 		CommandType: config.Defaults.CommandType,
+		PowerCondition: config.Defaults.PowerCondition,
 		Idle:        config.Defaults.Idle,
 	}
 }

--- a/main.go
+++ b/main.go
@@ -141,6 +141,23 @@ func main() {
 				os.Exit(1)
 			}
 
+		case "-p":
+			s, err := argument(index)
+			if err != nil {
+				fmt.Println("Missing power condition after -p. Must be a number from 0-15.")
+				os.Exit(1)
+			}
+			powerCondition, err := strconv.ParseUint(s, 0, 4)
+			if err != nil {
+				fmt.Printf("Invalid power condition %s: %s", s, err.Error())
+				os.Exit(1)
+			}
+			if deviceConf == nil {
+					config.Defaults.PowerCondition = uint8(powerCondition)
+					break
+				}
+				deviceConf.PowerCondition = uint8(powerCondition)
+
 		case "-l":
 			logfile, err := argument(index)
 			if err != nil {
@@ -159,7 +176,7 @@ func main() {
 	}
 
 	if singleDiskMode {
-		if err := spindownDisk(disk, config.Defaults.CommandType); err != nil {
+		if err := spindownDisk(disk, config.Defaults.CommandType, config.Defaults.PowerCondition); err != nil {
 			fmt.Println(err.Error())
 			os.Exit(1)
 		}

--- a/main.go
+++ b/main.go
@@ -104,6 +104,7 @@ func main() {
 				GivenName:   name,
 				Idle:        config.Defaults.Idle,
 				CommandType: config.Defaults.CommandType,
+				PowerCondition: config.Defaults.PowerCondition,
 			}
 
 		case "-i":

--- a/main.go
+++ b/main.go
@@ -211,7 +211,7 @@ func argument(index int) (string, error) {
 
 func usage() {
 	fmt.Println("usage: hd-idle [-t <disk>] [-s <symlink_policy>] [-a <name>] [-i <idle_time>] " +
-		"[-c <command_type>] [-l <logfile>] [-d] [-h]")
+		"[-c <command_type>] [-p power_condition] [-l <logfile>] [-d] [-h]")
 }
 
 func poolInterval(deviceConfs []DeviceConf) time.Duration {

--- a/sgio/scsi.go
+++ b/sgio/scsi.go
@@ -23,6 +23,7 @@ import (
 
 // https://en.wikipedia.org/wiki/SCSI_command
 const startStopUnit = 0x1b
+const standby = 0x30
 
 func StopScsiDevice(device string) error {
 	f, err := openDevice(device)
@@ -31,7 +32,14 @@ func StopScsiDevice(device string) error {
 	}
 
 	senseBuf := make([]byte, sgio.SENSE_BUF_LEN)
-	inqCmdBlk := []uint8{startStopUnit, 0, 0, 0, 0, 0}
+	//See https://www.seagate.com/files/staticfiles/support/docs/manual/Interface%20manuals/100293068j.pdf - 3.49 START STOP UNIT command
+	inqCmdBlk := []uint8{
+		startStopUnit, 
+		0, //Reserved (7 bit) + IMMED
+		0, //Reserved (8 bit)
+		0, //Reserved (4 bit) + POWER CONDITION MODIFER
+		standby, //POWER CONDITION + Reserved (1 bit) + NO_ FLUSH + LOEJ + LOEJ 
+		0} //CONTROL
 	ioHdr := &sgio.SgIoHdr{
 		InterfaceID:    'S',
 		DxferDirection: SgDxferNone,

--- a/sgio/scsi.go
+++ b/sgio/scsi.go
@@ -23,9 +23,8 @@ import (
 
 // https://en.wikipedia.org/wiki/SCSI_command
 const startStopUnit = 0x1b
-const standby = 0x30
 
-func StopScsiDevice(device string) error {
+func StartStopScsiDevice(device string, powerCondition uint8) error {
 	f, err := openDevice(device)
 	if err != nil {
 		return err
@@ -38,7 +37,7 @@ func StopScsiDevice(device string) error {
 		0, //Reserved (7 bit) + IMMED
 		0, //Reserved (8 bit)
 		0, //Reserved (4 bit) + POWER CONDITION MODIFER
-		standby, //POWER CONDITION + Reserved (1 bit) + NO_ FLUSH + LOEJ + LOEJ 
+		powerCondition, //POWER CONDITION + Reserved (1 bit) + NO_ FLUSH + LOEJ + LOEJ 
 		0} //CONTROL
 	ioHdr := &sgio.SgIoHdr{
 		InterfaceID:    'S',

--- a/sgio/scsi.go
+++ b/sgio/scsi.go
@@ -37,7 +37,7 @@ func StartStopScsiDevice(device string, powerCondition uint8) error {
 		0, //Reserved (7 bit) + IMMED
 		0, //Reserved (8 bit)
 		0, //Reserved (4 bit) + POWER CONDITION MODIFER
-		powerCondition, //POWER CONDITION + Reserved (1 bit) + NO_ FLUSH + LOEJ + LOEJ 
+		powerCondition << 4, //POWER CONDITION + Reserved (1 bit) + NO_ FLUSH + LOEJ + LOEJ 
 		0} //CONTROL
 	ioHdr := &sgio.SgIoHdr{
 		InterfaceID:    'S',


### PR DESCRIPTION
Support configuring the power condition sent with the START STOP UNIT command.
Using 0 results in stopping the disk completely means disk will not be started until it receives a start command.
Using power condition 2 / 3 can be used to activate idle / standby.

Feel a bit bad for not adding `power condition modifier`  to support  trigger standby_y (reduced RPM) mode... I just don't need it.

More information can be found in https://www.seagate.com/files/staticfiles/support/docs/manual/Interface%20manuals/100293068j.pdf in 3.49 START STOP UNIT command.
