### PR TITLE
fixed poolInterval calculation when using idle intervals of 0

### DIFF
--- a/main.go
+++ b/main.go
@@ -203,7 +203,7 @@ func poolInterval(deviceConfs []DeviceConf) time.Duration {
 
 	interval := defaultIdleTime
 	for _, dev := range deviceConfs {
-		if dev.Idle < interval {
+		if dev.Idle > 0 && dev.Idle < interval {
 			interval = dev.Idle
 		}
 	}


### PR DESCRIPTION
If any of the devices are configured with an idle interval of 0, the current implementation will result in a poolInterval of 1 second, which results in quite a bit of log spam. This pull request fixes this behaviour by ignoring these zero-values.