### PR TITLE
Use GivenName instead of Name in the log

### DIFF
--- a/main.go
+++ b/main.go
@@ -49,6 +49,7 @@ func main() {
 	var config = &Config{
 		Devices:  []DeviceConf{},
 		Defaults: defaultConf,
+		NameMap:  map[string]string{},
 	}
 	var deviceConf *DeviceConf
 
@@ -107,6 +108,7 @@ func main() {
 				CommandType:    config.Defaults.CommandType,
 				PowerCondition: config.Defaults.PowerCondition,
 			}
+			config.NameMap[deviceRealPath] = name
 
 		case "-i":
 			s, err := argument(index)


### PR DESCRIPTION
Change the device name in log and stdout to GivenName instead of Name.
Adding or removing disks will affect the assignment of /dev/sdX. So it makes sense to set a unique id for each disk. (This is common, just as [scrutiny](https://github.com/AnalogJ/scrutiny) also changed sdX to disk id).
Obviously, users with such a purpose won't pass sdX as a parameter, as they are dynamic. So I think using GivenName directly is acceptable. Also, for those users who do pass sdX as a parameter, the original functionality will not change.

Closes #65 