### PR TITLE
Allow ignoring in memory spindown state to issue spindown command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ debian/files
 debian/hd-idle.debhelper.log
 debian/hd-idle.substvars
 release
+pkg

--- a/README.md
+++ b/README.md
@@ -170,6 +170,10 @@ Command line options:
                         On systems with more than one disk, the disk where the log
                         is written will be spun up. On raspberry based systems the 
                         log should be written to the SD card.
++ -I
+                        Ignore spin down detection. Will trigger the spin down command even if hd-idle considers
+                        the disk to be spun down already. This is useful if the drive is spinning because of
+                        undetected activities (e.g SMART calls).
 
 Miscellaneous options:
 

--- a/debian/hd-idle.default
+++ b/debian/hd-idle.default
@@ -34,6 +34,10 @@ START_HD_IDLE=false
 #                          except for tuning purposes. On single-disk systems,
 #                          this option should not cause any additional spinups.
 #
+# -I
+#                          Ignore spin down detection. Will trigger the spin down command even if hd-idle considers
+#                          the disk to be spun down already. This is useful if the drive is spinning because of
+#                          undetected activities (e.g SMART calls).
 # Options not exactly useful here:
 #  -t <disk>               Spin-down the specified disk immediately and exit.
 #  -d                      Debug mode. It will print debugging info to

--- a/hdidle.go
+++ b/hdidle.go
@@ -283,8 +283,8 @@ func (c *Config) String() string {
 	for _, device := range c.Devices {
 		devices += "{" + device.String() + "}"
 	}
-	return fmt.Sprintf("symlinkPolicy=%d, defaultIdle=%v, defaultCommand=%s, defaultPowerCondition=%v, debug=%t, logFile=%s, devices=%s",
-		c.Defaults.SymlinkPolicy, c.Defaults.Idle.Seconds(), c.Defaults.CommandType, c.Defaults.PowerCondition, c.Defaults.Debug, c.Defaults.LogFile, devices)
+	return fmt.Sprintf("symlinkPolicy=%d, defaultIdle=%v, defaultCommand=%s, defaultPowerCondition=%v, debug=%t, logFile=%s, devices=%s, ignoreSpinDownDetection=%t",
+		c.Defaults.SymlinkPolicy, c.Defaults.Idle.Seconds(), c.Defaults.CommandType, c.Defaults.PowerCondition, c.Defaults.Debug, c.Defaults.LogFile, devices, c.Defaults.IgnoreSpinDownDetection)
 }
 
 func (dc *DeviceConf) String() string {

--- a/main.go
+++ b/main.go
@@ -127,6 +127,9 @@ func main() {
 			}
 			deviceConf.Idle = time.Duration(idle) * time.Second
 
+		case "-I":
+			config.Defaults.IgnoreSpinDownDetection = true
+
 		case "-c":
 			command, err := argument(index)
 			if err != nil {
@@ -219,7 +222,7 @@ func argument(index int) (string, error) {
 
 func usage() {
 	fmt.Println("usage: hd-idle [-t <disk>] [-s <symlink_policy>] [-a <name>] [-i <idle_time>] " +
-		"[-c <command_type>] [-p power_condition] [-l <logfile>] [-d] [-h]")
+		"[-c <command_type>] [-p power_condition] [-l <logfile>] [-d] [-I] [-h]")
 }
 
 func poolInterval(deviceConfs []DeviceConf) time.Duration {


### PR DESCRIPTION
As mentioned in some issues (e.g., [this one](https://github.com/adelolmo/hd-idle/pull/127#)), certain actions can spin up disks without generating any actual I/O.

As a result, hd-idle is unable to detect that the disk has been spun up, and it will not issue a spin-down command until new activity is detected.

This PR proposes adding an option that allows hd-idle to trigger a spin-down command regardless of the disk’s assumed spinning state. It also introduces a safeguard to prevent the disk from being spun down too frequently.