### PR TITLE
Add possibility to execute scripts after spinup or spindown

### DIFF
--- a/debian/hd-idle.8
+++ b/debian/hd-idle.8
@@ -73,6 +73,14 @@ because another disk had some activity. This option should not be used on
 systems with more than one disk except for tuning purposes. On single-disk
 systems, this option should not cause any additional spinups.
 .TP
+.B \-spinupscript path
+Absolute path to the script to be executed after disk spinup.
+The first argument passed to the script will be the name of the disk that has spun up.
+.TP
+.B \-spindownscript path
+Absolute path to the script to be executed after disk spindown.
+The first argument passed to the script will be the name of the disk that has spun down.
+.TP
 .B \-t disk
 Spin-down the specified disk immediately and exit. It can be used in combination
 with

--- a/debian/hd-idle.default
+++ b/debian/hd-idle.default
@@ -33,6 +33,10 @@ START_HD_IDLE=false
 #                          not be used on systems with more than one disk
 #                          except for tuning purposes. On single-disk systems,
 #                          this option should not cause any additional spinups.
+#  -spinupscript <path>    Absolute path to the script to be executed after disk spinup.
+#                          The first argument passed to the script will be the name of the disk that has spun up.
+#  -spindownscript <path>  Absolute path to the script to be executed after disk spindown.
+#                          The first argument passed to the script will be the name of the disk that has spun down.
 #
 # -I
 #                          Ignore spin down detection. Will trigger the spin down command even if hd-idle considers

--- a/hdidle.go
+++ b/hdidle.go
@@ -24,6 +24,7 @@ import (
 	"log"
 	"math"
 	"os"
+	"os/exec"
 	"time"
 )
 
@@ -41,6 +42,8 @@ type DefaultConf struct {
 	LogFile                 string
 	SymlinkPolicy           int
 	IgnoreSpinDownDetection bool
+	SpinUpScriptPath        string
+	SpinDownScriptPath      string
 }
 
 type DeviceConf struct {
@@ -152,6 +155,10 @@ func updateState(tmp DiskStats, config *Config) {
 					fmt.Printf("%s spindown\n",
 						config.resolveDeviceGivenName(ds.Name))
 				}
+				if len(config.Defaults.SpinDownScriptPath) > 0 {
+					executeBashScript(config.Defaults.SpinDownScriptPath, config.resolveDeviceGivenName(ds.Name))
+				}
+
 				device := fmt.Sprintf("/dev/%s", ds.Name)
 				if err := spindownDisk(device, ds.CommandType, ds.PowerCondition, config.Defaults.Debug); err != nil {
 					fmt.Println(err.Error())
@@ -168,6 +175,9 @@ func updateState(tmp DiskStats, config *Config) {
 			/* disk was spun down, thus it has just spun up */
 			fmt.Printf("%s spinup\n", config.resolveDeviceGivenName(ds.Name))
 			logSpinup(ds, config.Defaults.LogFile, config.resolveDeviceGivenName(ds.Name))
+			if len(config.Defaults.SpinUpScriptPath) > 0 {
+				executeBashScript(config.Defaults.SpinUpScriptPath, config.resolveDeviceGivenName(ds.Name))
+			}
 			previousSnapshots[dsi].SpinUpAt = now
 		}
 		previousSnapshots[dsi].Reads = tmp.Reads
@@ -264,6 +274,17 @@ func logSpinupAfterSleep(name, file string) {
 	text := fmt.Sprintf("date: %s, time: %s, disk: %s, assuming disk spun up after long sleep",
 		now.Format("2006-01-02"), now.Format("15:04:05"), name)
 	logToFile(file, text)
+}
+
+func executeBashScript(scriptPath string, diskName string) {
+	cmd := exec.Command("/bin/bash", scriptPath, diskName)
+
+	go func() {
+		output, err := cmd.CombinedOutput()
+		if err != nil {
+			fmt.Printf("Error executing script: %s, output: %s", err, string(output))
+		}
+	}()
 }
 
 func logToFile(file, text string) {

--- a/hdidle.go
+++ b/hdidle.go
@@ -25,6 +25,7 @@ import (
 	"math"
 	"os"
 	"os/exec"
+	"syscall"
 	"time"
 )
 
@@ -277,12 +278,38 @@ func logSpinupAfterSleep(name, file string) {
 }
 
 func executeBashScript(scriptPath string, diskName string) {
+	fi, err := os.Stat(scriptPath)
+	if err != nil {
+		fmt.Printf("Error stating script %q: %v\n", scriptPath, err)
+		return
+	}
+
+	if !fi.Mode().IsRegular() {
+		fmt.Printf("Refusing to execute non-regular file %q (mode: %v)\n", scriptPath, fi.Mode())
+		return
+	}
+
+	st, ok := fi.Sys().(*syscall.Stat_t)
+	if !ok {
+		fmt.Printf("Cannot read ownership information for %q\n", scriptPath)
+		return
+	}
+	if st.Uid != 0 {
+		fmt.Printf("Refusing to execute %q: not owned by root (uid=%d)\n", scriptPath, st.Uid)
+		return
+	}
+
+	if fi.Mode().Perm()&0100 == 0 {
+		fmt.Printf("Refusing to execute %q: not executable by root (mode: %v)\n", scriptPath, fi.Mode().Perm())
+		return
+	}
+
 	cmd := exec.Command("/bin/bash", scriptPath, diskName)
 
 	go func() {
 		output, err := cmd.CombinedOutput()
 		if err != nil {
-			fmt.Printf("Error executing script: %s, output: %s", err, string(output))
+			fmt.Printf("Error executing script %q: %v, output: %s\n", scriptPath, err, string(output))
 		}
 	}()
 }

--- a/main.go
+++ b/main.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"github.com/adelolmo/hd-idle/io"
 	"os"
+	"path"
 	"strconv"
 	"time"
 )
@@ -172,6 +173,30 @@ func main() {
 				os.Exit(1)
 			}
 			config.Defaults.LogFile = logfile
+
+		case "-spinupscript":
+			spinupScriptPath, err := argument(index)
+			if err != nil {
+				fmt.Println("Missing path after -spinupscript.")
+				os.Exit(1)
+			}
+			if !path.IsAbs(spinupScriptPath) {
+				fmt.Println("Path for spinup script must be an absolute path.")
+				os.Exit(1)
+			}
+			config.Defaults.SpinUpScriptPath = spinupScriptPath
+
+		case "-spindownscript":
+			spindownScriptPath, err := argument(index)
+			if err != nil {
+				fmt.Println("Missing path after -spindownscript.")
+				os.Exit(1)
+			}
+			if !path.IsAbs(spindownScriptPath) {
+				fmt.Println("Path for spindown script must be an absolute path.")
+				os.Exit(1)
+			}
+			config.Defaults.SpinDownScriptPath = spindownScriptPath
 
 		case "-d":
 			config.Defaults.Debug = true


### PR DESCRIPTION
This is a feature I personally required. What I use it for:

- send notification to Home Assistant on spin-up and on spin-down so I can track HDD state in Home Assistant
- execute `df` command after spin-up and send output to Home Assistant - allows me to track free space left on disk (alternatives like periodically executing the `df` command via ssh would oftentimes spin-up the drive unnecessarily).

I considered building a service to observe the system journal for hd-idle's logs, but this solution proved much nicer.

**Important note:**
I'm not a security expert, but I imagine there's a potential security risk, as hd-idle runs as root and will therefore execute the given scripts as root. So I can understand if there are concerns here. If you think this feature is nice to have, maybe someone with more security expertise can review and potentially advise on how to secure this. Otherwise, feel free to close this PR, all good. Just wanted to offer to contribute back the work I put in.

Thanks for this great tool!