### PR TITLE
Fix Makefile for Debian 13

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ uninstall:
 	rm -f $(TARGET_DIR)/sbin/$(TARGET)
 
 $(TARGET):
-	GOOS=linux GOARCH=$(GOARCH) go build
+	GO111MODULE=on GOOS=linux GOARCH=$(GOARCH) go build
 
 test:
-	go test ./... -race -cover
+	GO111MODULE=on go test ./... -race -cover


### PR DESCRIPTION
Addresses issue #135. For some reason in Debian 13 when building with `dpkg-buildpackage`, the environment has `GO111MODULE=off`, so it doesn't load the modules, causing the build to fail. As a simple workaround I set `GO111MODULE=on` before the Go commands in the Makefile, not sure if there's a better way.