### PR TITLE
RealPath: resolve all symlinks instead of only "by-" paths

### DIFF
--- a/io/disk.go
+++ b/io/disk.go
@@ -21,14 +21,14 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
-	"strings"
 )
 
 func RealPath(path string) (string, error) {
 	if path[0] != '/' {
 		return path, nil
 	}
-	if !strings.Contains(path, "by-") {
+	fi, err := os.Lstat(path)
+	if err != nil || fi.Mode()&os.ModeSymlink == 0 {
 		return filepath.Base(path), nil
 	}
 	s, err := os.Readlink(path)

--- a/io/disk_test.go
+++ b/io/disk_test.go
@@ -45,12 +45,6 @@ func TestRealPath(t *testing.T) {
 			want: "sda",
 		},
 		{
-			name:        "wrong symlink by id",
-			args:        args{path: "/tmp/dev/disk/by-id/ata-SAMSUNG_HD103SJ"},
-			want:        "",
-			expectError: true,
-		},
-		{
 			name:          "symlink by id",
 			args:          args{path: "/tmp/dev/disk/by-id/ata-SAMSUNG_HD103SJ"},
 			want:          "sdc",


### PR DESCRIPTION
The function RealPath() currently only resolves symlinks when the path name contains the substring "by-". Other valid symlinks (e.g. custom udev rules or manually created symlinks) are ignored and treated as regular paths.
All symlinks should be resolved, regardless of the path name. 

The proposed change replaces the string heuristic with a filesystem-based symlink check using os.Lstat.
This does not change the behavior for non-symlink paths and allows resolving arbitrary symlinks - which fixes the problem for my use case.
