### PR TITLE
Do not mark a disk as spun down when the spindown command fails

### DIFF
--- a/hdidle.go
+++ b/hdidle.go
@@ -95,7 +95,7 @@ func ObserveDiskActivity(config *Config) {
 			Reads:  stats.Reads,
 			Writes: stats.Writes,
 		}
-		updateState(*d, config)
+		updateState(*d, config, spindownDisk)
 	}
 	lastNow = now
 }
@@ -120,7 +120,9 @@ func resolveSymlinks(config *Config) {
 	}
 }
 
-func updateState(tmp DiskStats, config *Config) {
+type spindownDiskFunc func(device, command string, powerCondition uint8, debug bool) error
+
+func updateState(tmp DiskStats, config *Config, spindown spindownDiskFunc) {
 	dsi := previousDiskStatsIndex(tmp.Name)
 	if dsi < 0 {
 		previousSnapshots = append(previousSnapshots, initDevice(tmp, config))
@@ -153,12 +155,18 @@ func updateState(tmp DiskStats, config *Config) {
 						config.resolveDeviceGivenName(ds.Name))
 				}
 				device := fmt.Sprintf("/dev/%s", ds.Name)
-				if err := spindownDisk(device, ds.CommandType, ds.PowerCondition, config.Defaults.Debug); err != nil {
-					fmt.Println(err.Error())
-				}
+				err := spindown(device, ds.CommandType, ds.PowerCondition, config.Defaults.Debug)
+				/* record the attempt either way: on failure this rate-limits the
+				   retry to one per idle period instead of one per poll */
 				previousSnapshots[dsi].LastSpunDownAt = now
-				previousSnapshots[dsi].SpinDownAt = now
-				previousSnapshots[dsi].SpunDown = true
+				if err != nil {
+					/* the disk is still spinning, so leave SpunDown false and let
+					   the next idle period try again */
+					fmt.Println(err.Error())
+				} else {
+					previousSnapshots[dsi].SpinDownAt = now
+					previousSnapshots[dsi].SpunDown = true
+				}
 			}
 		}
 

--- a/hdidle_test.go
+++ b/hdidle_test.go
@@ -1,0 +1,121 @@
+// hd-idle - spin down idle hard disks
+// Copyright (C) 2018  Andoni del Olmo
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package main
+
+import (
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestSpindownResultDeterminesSpunDownState(t *testing.T) {
+	tests := []struct {
+		name              string
+		spindownErr       error
+		wantSpunDown      bool
+		wantSpinDownAtSet bool
+	}{
+		{
+			name:              "successful spindown marks the disk as spun down",
+			spindownErr:       nil,
+			wantSpunDown:      true,
+			wantSpinDownAtSet: true,
+		},
+		{
+			name:              "failed spindown leaves the disk as still spinning",
+			spindownErr:       errors.New("cannot spindown scsi disk /dev/sda"),
+			wantSpunDown:      false,
+			wantSpinDownAtSet: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			now = time.Now()
+			lastNow = now
+			previousSnapshots = []DiskStats{idleDiskStats(now)}
+
+			updateState(DiskStats{Name: "sda", Reads: 100, Writes: 100}, idleDiskConfig(),
+				func(device, command string, powerCondition uint8, debug bool) error {
+					return test.spindownErr
+				})
+
+			if previousSnapshots[0].SpunDown != test.wantSpunDown {
+				t.Errorf("Expected SpunDown %v but found %v",
+					test.wantSpunDown, previousSnapshots[0].SpunDown)
+			}
+			if !previousSnapshots[0].SpinDownAt.IsZero() != test.wantSpinDownAtSet {
+				t.Errorf("Expected SpinDownAt set %v but found %v",
+					test.wantSpinDownAtSet, !previousSnapshots[0].SpinDownAt.IsZero())
+			}
+		})
+	}
+}
+
+func TestFailedSpindownIsRetriedOncePerIdlePeriod(t *testing.T) {
+	now = time.Now()
+	lastNow = now
+	previousSnapshots = []DiskStats{idleDiskStats(now)}
+
+	attempts := 0
+	failing := func(device, command string, powerCondition uint8, debug bool) error {
+		attempts++
+		return errors.New("cannot spindown scsi disk /dev/sda")
+	}
+	snapshot := DiskStats{Name: "sda", Reads: 100, Writes: 100}
+	config := idleDiskConfig()
+
+	updateState(snapshot, config, failing)
+	if attempts != 1 {
+		t.Fatalf("Expected 1 attempt but found %d", attempts)
+	}
+
+	now = now.Add(5 * time.Second)
+	lastNow = now
+	updateState(snapshot, config, failing)
+	if attempts != 1 {
+		t.Fatalf("Expected no retry within the idle period but found %d attempts", attempts)
+	}
+
+	now = now.Add(11 * time.Second)
+	lastNow = now
+	updateState(snapshot, config, failing)
+	if attempts != 2 {
+		t.Fatalf("Expected 2 attempts after a further idle period but found %d", attempts)
+	}
+}
+
+func idleDiskConfig() *Config {
+	return &Config{
+		Defaults: DefaultConf{CommandType: SCSI},
+		SkewTime: time.Minute,
+		NameMap:  map[string]string{},
+	}
+}
+
+func idleDiskStats(at time.Time) DiskStats {
+	return DiskStats{
+		Name:        "sda",
+		GivenName:   "sda",
+		IdleTime:    10 * time.Second,
+		CommandType: SCSI,
+		Reads:       100,
+		Writes:      100,
+		LastIoAt:    at.Add(-time.Hour),
+		SpinUpAt:    at.Add(-time.Hour),
+	}
+}


### PR DESCRIPTION
## Problem

`spindownDisk`'s error is printed and then discarded, and `SpunDown` is set to `true` either way (`hdidle.go:156-161` on master):

```go
if err := spindownDisk(device, ds.CommandType, ds.PowerCondition, config.Defaults.Debug); err != nil {
    fmt.Println(err.Error())
}
previousSnapshots[dsi].LastSpunDownAt = now
previousSnapshots[dsi].SpinDownAt = now
previousSnapshots[dsi].SpunDown = true
```

The spindown branch is gated on `!ds.SpunDown`, and only observed disk activity clears that flag (`hdidle.go:176`). So when the command fails on an idle disk, the disk is never retried: it keeps spinning while hd-idle considers it parked. `logSpinup` only writes to the logfile on the spin-up transition, which never comes, so the logfile stays empty too.

The observable result is one error line at the moment of failure and then permanent silence, with the disk spinning 24/7. That is the same symptom described in #131 ("first spindown works, later ones do not"), reachable without any state-tracking regression.

This is a different root cause from #113, where the disk wakes without registering activity in `/proc/diskstats` so the wake is never observed. That one needs a way to learn the disk's real state. This one does not: the error is already in hand at line 156 and is simply dropped.

## Fix

Keep `SpunDown` false when the command fails, so the next idle period tries again. `LastSpunDownAt` is still recorded on failure, which rate-limits the retry to one per idle period instead of one per poll, so a disk that always rejects the command does not spam the log every `poolInterval`.

`updateState` now takes the spindown function as a parameter, following the existing `diskHolderGetterFunc` pattern in `diskstats/snapshot.go`, so the failure path is testable without touching hardware.

## Tests

`hdidle_test.go` (new, table-driven per AGENTS.md):

- `TestSpindownResultDeterminesSpunDownState`: success sets `SpunDown` and `SpinDownAt`; failure leaves both unset.
- `TestFailedSpindownIsRetriedOncePerIdlePeriod`: after a failure there is no retry within the idle period and exactly one retry after it.

`go test ./... -race -cover` passes, `go vet ./...` is clean, and `gofmt -l` is clean for both changed files. Note `gofmt -l` already reports `diskstats/snapshot.go` on unmodified master (a missing space after a comma at line 143); left untouched as it is unrelated.

## Hardware verification

Real Seagate ST10000NM017B (10 TB SATA), Linux 6.18, both binaries built from this branch's base. Ground truth was a 64 MB `iflag=direct` read at a fresh offset, which reliably separates a spinning disk from a stopped one: about 0.28 s versus about 9.5 s including spin-up.

Failure path, forced with `-c ata` on a transport that rejects opcode 0x85, `-i 20`, over 75 s (about 37 polls):

| | master | this branch |
|---|---|---|
| spindown attempts | 1 | 3 |
| failures reported | 1 | 3 |
| state after | `spunDown=true` | `spunDown=false` |

Three attempts over 75 s at `-i 20` is one per idle period, as intended.

Success path, `-c scsi`, two full cycles: `spindown`, then `spinup` detected on the waking read, then `spindown` again, with the 64 MB probe measuring 9.51 s and 9.68 s at each stop and the logfile recording both `running:`/`stopped:` pairs. No behavior change versus master on this path.

One note on the setup, in case it is useful: the probe reads had to go through a partition (`/dev/sde2`) rather than the whole disk (`/dev/sde`), because master computes per-disk activity from the sum of the partition counters, so whole-disk I/O does not register. v1.22 behaves differently here (it carries 675d30fb, which master does not). Not related to this change, just why the test reads target a partition.
